### PR TITLE
Add --max-size flag to limit size of repositories

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -41,7 +41,7 @@ func init() {
 	flags.BoolVar(&server.Debug, "debug", server.Debug, "output debug messages")
 	flags.StringVar(&server.Listen, "listen", server.Listen, "listen address")
 	flags.StringVar(&server.Log, "log", server.Log, "log HTTP requests in the combined log format")
-	flags.Uint64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
+	flags.Int64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
 	flags.StringVar(&server.Path, "path", server.Path, "data directory")
 	flags.BoolVar(&server.TLS, "tls", server.TLS, "turn on TLS support")
 	flags.StringVar(&server.TLSCert, "tls-cert", server.TLSCert, "TLS certificate path")

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -41,6 +41,7 @@ func init() {
 	flags.BoolVar(&server.Debug, "debug", server.Debug, "output debug messages")
 	flags.StringVar(&server.Listen, "listen", server.Listen, "listen address")
 	flags.StringVar(&server.Log, "log", server.Log, "log HTTP requests in the combined log format")
+	flags.Uint64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
 	flags.StringVar(&server.Path, "path", server.Path, "data directory")
 	flags.BoolVar(&server.TLS, "tls", server.TLS, "turn on TLS support")
 	flags.StringVar(&server.TLSCert, "tls-cert", server.TLSCert, "TLS certificate path")

--- a/handlers.go
+++ b/handlers.go
@@ -555,6 +555,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			atomic.StoreUint64(&s.repoSize, initialSize)
+			currentSize = initialSize
 		}
 
 		if currentSize+uint64(contentLen) > s.MaxRepoSize {

--- a/handlers.go
+++ b/handlers.go
@@ -565,7 +565,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 				log.Printf("incoming blob (%d bytes) would go over maximum size of repository (%d bytes)",
 					contentLen, s.MaxRepoSize)
 			}
-			http.Error(w, http.StatusText(http.StatusInsufficientStorage), http.StatusInsufficientStorage)
+			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 			return
 		}
 
@@ -613,7 +613,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 			if s.Debug {
 				log.Printf("wrote %d/%d bytes (space limit reached: %d bytes)", written, contentLen, s.MaxRepoSize)
 			}
-			http.Error(w, http.StatusText(http.StatusInsufficientStorage), http.StatusInsufficientStorage)
+			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 			return
 		}
 	}


### PR DESCRIPTION
The --max-size limits the number of bytes that can be stored to a repo. It only takes effect on `SaveBlob`.

TODO: `restic` should not retry if the server responds with `413 Request Entity Too Large`.

Closes https://github.com/restic/rest-server/issues/65

/cc @fd0 @dotlambda